### PR TITLE
Update the version reference for TEAM Engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opengis.cite</groupId>
   <artifactId>ets-common</artifactId>
-  <version>10-SNAPSHOT</version>
+  <version>9</version>
   <packaging>pom</packaging>
 
   <name>Common ETS POM</name>
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>org.opengis.cite.teamengine</groupId>
         <artifactId>teamengine-spi</artifactId>
-        <version>4.9</version>
+        <version>5.3</version>
       </dependency>
       <dependency>
         <groupId>org.opengis.cite</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opengis.cite</groupId>
   <artifactId>ets-common</artifactId>
-  <version>9</version>
+  <version>10-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Common ETS POM</name>


### PR DESCRIPTION
The ETS code pom.xml files should be referencing TEAM Engine 5.3 as the default and many
ETS code pom files do not include a specific version. Since this is the 'parent', they end up with
the version specified here.