### PR TITLE
Adjust to additional testsuites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <jackson.version>2.18.0</jackson.version>
     <jersey.version>3.1.8</jersey.version>
     <jhove.version>1.16.6</jhove.version>
+    <jadler.version>1.3.0</jadler.version>
     <soapui.test.fail.ignore>false</soapui.test.fail.ignore>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
@@ -205,12 +206,12 @@
       <dependency>
         <groupId>net.jadler</groupId>
         <artifactId>jadler-core</artifactId>
-        <version>1.3.0</version>
+        <version>${jadler.version}</version>
       </dependency>
       <dependency>
         <groupId>net.jadler</groupId>
         <artifactId>jadler-jetty</artifactId>
-        <version>1.3.0</version>
+        <version>${jadler.version}</version>
       </dependency>
       <dependency>
         <groupId>org.openpreservation.jhove</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opengis.cite</groupId>
@@ -211,20 +212,20 @@
         <artifactId>jadler-jetty</artifactId>
         <version>1.3.0</version>
       </dependency>
-	  <dependency>
-	    <groupId>org.openpreservation.jhove</groupId>
-	    <artifactId>jhove-modules</artifactId>
-	    <version>${jhove.version}</version>
-	  </dependency>
-	  <dependency>
-	    <groupId>org.openpreservation.jhove</groupId>
-	    <artifactId>jhove-core</artifactId>
-	    <version>${jhove.version}</version>
-	  </dependency>
       <dependency>
-	      <groupId>org.apache.commons</groupId>
-	      <artifactId>commons-csv</artifactId>
-	      <version>1.5</version>
+        <groupId>org.openpreservation.jhove</groupId>
+        <artifactId>jhove-modules</artifactId>
+        <version>${jhove.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openpreservation.jhove</groupId>
+        <artifactId>jhove-core</artifactId>
+        <version>${jhove.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-csv</artifactId>
+        <version>1.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.jena</groupId>
@@ -306,9 +307,9 @@
         <version>2.12.2</version>
         <exclusions>
           <exclusion>
-      		  <groupId>xml-apis</groupId>
-      		  <artifactId>xml-apis</artifactId>
-      		</exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -629,9 +629,6 @@
             <version>3.1.1</version>
           </dependency>
         </dependencies>
-        <configuration>
-          <relativizeDecorationLinks>false</relativizeDecorationLinks>
-        </configuration>
       </plugin>
     </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.12.1</version>
+        <version>3.21.0</version>
         <executions>
           <execution>
             <id>site-package</id>
@@ -615,18 +615,18 @@
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.doxia</groupId>
-            <artifactId>doxia-module-xhtml</artifactId>
-            <version>1.12.0</version>
+            <artifactId>doxia-module-xhtml5</artifactId>
+            <version>2.0.0</version>
           </dependency>
           <dependency>
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-module-markdown</artifactId>
-            <version>1.12.0</version>
+            <version>2.0.0</version>
           </dependency>
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctor-converter-doxia-module</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.1</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -658,7 +658,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,12 @@
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>2.12.2</version>
+        <exclusions>
+          <exclusion>
+      		  <groupId>xml-apis</groupId>
+      		  <artifactId>xml-apis</artifactId>
+      		</exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <teamengine.version>6.0.0-RC2</teamengine.version>
     <jackson.version>2.18.0</jackson.version>
     <jersey.version>3.1.8</jersey.version>
+    <jhove.version>1.16.6</jhove.version>
     <soapui.test.fail.ignore>false</soapui.test.fail.ignore>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
@@ -189,6 +190,56 @@
         <groupId>org.locationtech.jts</groupId>
         <artifactId>jts-core</artifactId>
         <version>1.19.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.locationtech.proj4j</groupId>
+        <artifactId>proj4j</artifactId>
+        <version>1.1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.locationtech.jts.io</groupId>
+        <artifactId>jts-io-common</artifactId>
+        <version>1.18.1</version>
+      </dependency>
+      <dependency>
+        <groupId>net.jadler</groupId>
+        <artifactId>jadler-core</artifactId>
+        <version>1.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>net.jadler</groupId>
+        <artifactId>jadler-jetty</artifactId>
+        <version>1.3.0</version>
+      </dependency>
+	  <dependency>
+	    <groupId>org.openpreservation.jhove</groupId>
+	    <artifactId>jhove-modules</artifactId>
+	    <version>${jhove.version}</version>
+	  </dependency>
+	  <dependency>
+	    <groupId>org.openpreservation.jhove</groupId>
+	    <artifactId>jhove-core</artifactId>
+	    <version>${jhove.version}</version>
+	  </dependency>
+      <dependency>
+	      <groupId>org.apache.commons</groupId>
+	      <artifactId>commons-csv</artifactId>
+	      <version>1.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-iri</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openapi4j</groupId>
+        <artifactId>openapi-operation-validator</artifactId>
+        <version>1.0.7</version>
+      </dependency>
+      <dependency>
+        <groupId>com.networknt</groupId>
+        <artifactId>json-schema-validator</artifactId>
+        <version>1.0.66</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
Adds dependencies used by additional TestNG based test suites that were migrated to Java 17.
Also closes #20 